### PR TITLE
Copy pppd install directories in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/pytho
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /app /app
 
-# TODO: do not need entire build folder...
-COPY --from=builder /ppp_ws /ppp_ws
+# Build for pppd installs to the following locations
+COPY --from=builder /usr/local/etc /usr/local/etc
+COPY --from=builder /usr/local/include /usr/local/include
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/sbin /usr/local/sbin
+COPY --from=builder /usr/local/share /usr/local/share
 
 EXPOSE 8000/tcp
 

--- a/app/ppp_process.py
+++ b/app/ppp_process.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 logger = logging.getLogger("ppp.daemon")
 
-PPPD_EXECUTABLE = Path("/ppp_ws/ppp/pppd/pppd")
-# PPPD_EXECUTABLE = Path("/shortcuts/userdata/code/ppp_ws/ppp/pppd/pppd"),
+# pppd is installed to /usr/local/sbin
+PPPD_EXECUTABLE = Path("/usr/local/sbin/pppd")
 
 
 class PPPDaemon:


### PR DESCRIPTION
Trim size of image by only copying installed files. Update script to run `pppd` from `/usr/local/sbin`
